### PR TITLE
Fix failure to solve under certain conditions

### DIFF
--- a/Assets/topsyTurvy.cs
+++ b/Assets/topsyTurvy.cs
@@ -100,7 +100,7 @@ public class topsyTurvy : MonoBehaviour
                 StopCoroutine(cycle);
                 cycle = null;
             }
-            var submitted = currentPos - 1;
+            var submitted = currentPos;
             if (submitted != solution)
             {
                 module.HandleStrike();
@@ -122,12 +122,12 @@ public class topsyTurvy : MonoBehaviour
 	{
 		var count = decoyWords.Count();
 		screenTexts[0].text = "";
-		currentPos = 0;
+		currentPos = -1;
 		while (true)
 		{
+			currentPos = (currentPos + 1) % count;
 			screenTexts[1].color = textColors.PickRandom();
 			screenTexts[1].text = decoyWords[currentPos];
-			currentPos = (currentPos + 1) % count;
             yield return new WaitForSeconds(1f);
         }
 	}


### PR DESCRIPTION
* The correct word (in this case, "robot") was at the very end of the array of words it cycled through
* CycleWords() increments currentPos immediately after displaying the word
* ... and to compensate for the above, ReleaseButton() uses submitted = currentPos - 1 to fetch the index of the word that's actually on the display.
* but, if it's released on the last word in the list, currentPos is 0, so submitted becomes -1. Obviously, that's not the answer it's looking for, so it awards a strike, and the log print afterwards throws an exception for trying to use an invalid array index (decoyWords[-1])).